### PR TITLE
Add support for select to useValue

### DIFF
--- a/packages/react-zorm/src/utils.ts
+++ b/packages/react-zorm/src/utils.ts
@@ -3,7 +3,8 @@ export function isValuedElement(
 ): input is HTMLInputElement | HTMLTextAreaElement {
     return (
         input instanceof HTMLInputElement ||
-        input instanceof HTMLTextAreaElement
+        input instanceof HTMLTextAreaElement ||
+        input instanceof HTMLSelectElement
     );
 }
 


### PR DESCRIPTION
`useValue` does not work with `<select>`. This PR fixes this.

Happy to add tests in a follow-up. I don't have much time right now.