### PR TITLE
Add unstable `inputProps()`

### DIFF
--- a/packages/react-zorm/__tests__/input-props.test.tsx
+++ b/packages/react-zorm/__tests__/input-props.test.tsx
@@ -1,0 +1,9 @@
+import { z } from "zod";
+import { unstable_inputProps as inputProps } from "../src";
+
+test("sets type=text by default", () => {
+    const props = inputProps({ name: "test", type: z.string() });
+    expect(props).toEqual({ name: "test", type: "text", required: true });
+});
+
+// TODO more tests

--- a/packages/react-zorm/package.json
+++ b/packages/react-zorm/package.json
@@ -81,7 +81,7 @@
   "size-limit": [
     {
       "path": "esm/react-zorm.mjs",
-      "limit": "2.5 KB"
+      "limit": "3 KB"
     }
   ]
 }

--- a/packages/react-zorm/src/index.tsx
+++ b/packages/react-zorm/src/index.tsx
@@ -4,3 +4,7 @@ export { useZorm } from "./use-zorm";
 export type { Zorm, ZodCustomIssueWithMessage, RenderProps } from "./types";
 export type { ValueSubscription } from "./use-value";
 export { useValue, Value } from "./use-value";
+export {
+    inputProps as unstable_inputProps,
+    type InputProps,
+} from "./input-props";

--- a/packages/react-zorm/src/input-props.ts
+++ b/packages/react-zorm/src/input-props.ts
@@ -1,0 +1,156 @@
+import {
+    ZodType,
+    ZodEffects,
+    ZodString,
+    ZodNumber,
+    ZodDate,
+    ZodDefault,
+    ZodOptional,
+    ZodNullable,
+} from "zod";
+
+export interface InputProps {
+    type: string;
+    name: string;
+    required?: boolean;
+    min?: number;
+    max?: number;
+    minLength?: number;
+    maxLength?: number;
+    pattern?: string;
+    step?: string | number;
+    defaultValue?: string | number;
+}
+
+function removeZodEffects(type: ZodType): ZodType {
+    // remove .refine() etc.
+    if (type instanceof ZodEffects) {
+        return removeZodEffects(type.innerType());
+    }
+
+    return type;
+}
+
+function stringCheckProps(type: ZodString) {
+    const checks = type._def.checks;
+
+    const props: Partial<InputProps> = {
+        type: "text",
+    };
+
+    for (const check of checks) {
+        if (check.kind === "min") {
+            props.minLength = check.value;
+        }
+
+        if (check.kind === "max") {
+            props.maxLength = check.value;
+        }
+
+        if (check.kind === "regex") {
+            props.pattern = check.regex.toString().slice(1, -1);
+        }
+
+        if (check.kind === "email") {
+            props.type = "email";
+        }
+
+        // TODO the rest...
+    }
+
+    return props;
+}
+
+function numberCheckProps(type: ZodNumber) {
+    const checks = type._def.checks;
+
+    const props: Partial<InputProps> = {
+        type: "number",
+        step: "any",
+    };
+
+    for (const check of checks) {
+        if (check.kind === "min") {
+            props.min = check.value;
+        }
+
+        if (check.kind === "max") {
+            props.max = check.value;
+        }
+
+        if (check.kind === "int" && props.step === "any") {
+            // defaults to 1 so we can remove it if limited to ints
+            delete props.step;
+        }
+
+        if (check.kind === "multipleOf") {
+            props.step = check.value;
+        }
+    }
+
+    return props;
+}
+
+function dateCheckProps(type: ZodDate) {
+    const checks = type._def.checks;
+
+    const props: Partial<InputProps> = {
+        type: "date",
+    };
+
+    for (const check of checks) {
+        if (check.kind === "min") {
+            props.min = check.value;
+        }
+
+        if (check.kind === "max") {
+            props.max = check.value;
+        }
+    }
+
+    return props;
+}
+
+function collectProps(
+    type: ZodType,
+    _props: Partial<InputProps> = {},
+): Partial<InputProps> {
+    const props = _props ?? {};
+
+    type = removeZodEffects(type);
+
+    if (type instanceof ZodDefault) {
+        props.defaultValue = type._def.defaultValue();
+    } else if (type instanceof ZodOptional || type instanceof ZodNullable) {
+        props.required = false;
+    } else if (type instanceof ZodString) {
+        Object.assign(props, stringCheckProps(type));
+    } else if (type instanceof ZodNumber) {
+        Object.assign(props, numberCheckProps(type));
+    } else if (type instanceof ZodDate) {
+        Object.assign(props, dateCheckProps(type));
+    }
+
+    // Remove optional/nullable wrapping etc. There's probably a better way to do this.
+    const anyType = type as any;
+    if (anyType._def?.innerType) {
+        return collectProps(anyType._def.innerType, props);
+    }
+
+    return props;
+}
+
+export function inputProps(field: { name: string; type: ZodType }): InputProps {
+    const props: InputProps = {
+        type: "text",
+        required: true,
+        ...collectProps(field.type),
+        name: field.name,
+    };
+
+    if (props.required === false) {
+        delete props.required;
+    }
+
+    return props;
+}


### PR DESCRIPTION
Instead of 

```tsx
<input type="text" name={zo.fields.username()} />;
```

you can now do

```tsx
import { unstable_inputProps as inputProps } from "react-zorm";

// ...

<input {...zo.fields.username(inputProps)} />;
```

And it will set automatically the relevant props, whether it is a number, date etc.